### PR TITLE
Add menu string support to LCD1 menuSelect

### DIFF
--- a/examples/Tiger/Tiger Python/td01-lcd/ESC/menu_select.py
+++ b/examples/Tiger/Tiger Python/td01-lcd/ESC/menu_select.py
@@ -1,35 +1,35 @@
 from Tiger import LCD1
 import time
 
+# Menu items to display. A colon separates each entry and the
+# string ends with a double colon.
 MENU_ITEMS = ["AUTO", "MANUAL", "ALARM", "STOP"]
 MENU_STR = ":" + ":".join(MENU_ITEMS) + "::"
 
 lcd = LCD1(kbd_on=True)
 
 
-def show_menu(index):
+def show_menu(idx):
     lcd.clear()
-    lcd.writeString("your choice:")
+    lcd.writeString("select:")
     lcd.cursorPosition(0, 1)
-    lcd.menuSelect(index, MENU_STR)
+    lcd.menuSelect(idx, MENU_STR)
 
 
 index = 0
-running = True
-
-while running:
+while True:
     show_menu(index)
     while lcd.getKeyboardBufferSize() == 0:
         time.sleep_ms(10)
     key = lcd.readKeyboard(1)
     if key == b"\r":
-        running = False
-    elif key == b"\x0b":  # Up key
+        break
+    elif key == b"\x0b":
         index = (index - 1) % len(MENU_ITEMS)
-    elif key == b"\x0a":  # Down key
+    elif key == b"\x0a":
         index = (index + 1) % len(MENU_ITEMS)
 
 lcd.clear()
-lcd.writeString("Menu index is:")
+lcd.writeString("menu index:")
 lcd.cursorPosition(0, 1)
 lcd.writeString(str(index))

--- a/ports/stm32/td01-lcd.c
+++ b/ports/stm32/td01-lcd.c
@@ -679,16 +679,30 @@ static mp_obj_t tiger_lcd1_reset_special(mp_obj_t self_in, mp_obj_t n)
 }
 static MP_DEFINE_CONST_FUN_OBJ_2(tiger_lcd1_reset_special_obj, tiger_lcd1_reset_special);
 
-static mp_obj_t tiger_lcd1_menu_select(mp_obj_t self_in, mp_obj_t idx) {
+static mp_obj_t tiger_lcd1_menu_select(mp_obj_t self_in, mp_obj_t idx, mp_obj_t menu) {
     uint8_t index = mp_obj_int_get_uint_checked(idx);
-	
+
+    const char *str;
+    size_t len;
+    if (mp_obj_is_str(menu)) {
+        str = mp_obj_str_get_data(menu, &len);
+    } else if (mp_obj_is_type(menu, &mp_type_bytes)) {
+        uint8_t temp[1];
+        mp_buffer_info_t bufinfo;
+        pyb_buf_get_for_send(menu, &bufinfo, temp);
+        str = (const char *)bufinfo.buf;
+        len = bufinfo.len;
+    } else {
+        mp_raise_TypeError(MP_ERROR_TEXT("menu must be a string"));
+    }
+
     uint8_t cmd[] = {0x1B, 'M', index, 0xF0};
-	
     add_to_obuf(cmd, 4);
-	
+    add_to_obuf(str, len);
+
     return mp_const_none;
 }
-static MP_DEFINE_CONST_FUN_OBJ_2(tiger_lcd1_menu_select_obj, tiger_lcd1_menu_select);
+static MP_DEFINE_CONST_FUN_OBJ_3(tiger_lcd1_menu_select_obj, tiger_lcd1_menu_select);
 
 static mp_obj_t tiger_lcd1_cursor_off(mp_obj_t self_in) 
 {


### PR DESCRIPTION
## Summary
- extend `menuSelect` method in `td01-lcd.c` to accept a menu string
- update example to demonstrate menu string selection
- add new `menu_select.py` example for interactive testing

## Testing
- `ruff format examples/Tiger/Tiger Python/td01-lcd/ESC/menu_select.py examples/Tiger/Tiger Python/td01-lcd/ESC/main.py`
- `tools/codeformat.py ports/stm32/td01-lcd.c` *(fails: uncrustify not installed)*
- `python3 tests/run-tests.py basics/builtin_len.py` *(fails: micropython executable missing)*

------
https://chatgpt.com/codex/tasks/task_b_685bbc3ee8b0832f86a9c9d418a459f3